### PR TITLE
Fix deactivate widget ancestor is unsafe during scroll to view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-#### [1.0.8] - July 23, 2024
+#### [1.0.9] - August 05, 2024
 
 - renamed `dynamicHeightItem` to `dynamicHeight`
 - Fix exception on scroll (debug) [Issue #162](https://github.com/maheshj01/searchfield/issues/162)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 #### [1.0.8] - July 23, 2024
 
+- renamed `dynamicHeightItem` to `dynamicHeight`
+- Fix exception on scroll (debug) [Issue #162](https://github.com/maheshj01/searchfield/issues/162)
+
+#### [1.0.8] - July 23, 2024
+
 - Fixed Regression: Broke basic functionality to search [hotfix #161](https://github.com/maheshj01/searchfield/pull/161)
 
 #### [1.0.7] - July 22, 2024

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [searchfield: ^1.0.8](https://pub.dev/packages/searchfield)
+# [searchfield: ^1.0.9](https://pub.dev/packages/searchfield)
 
 <a href="https://github.com/maheshj01/searchfield" rel="noopener" target="_blank"><img src="https://img.shields.io/badge/platform-flutter-ff69b4.svg" alt="Flutter Platform Badge"></a>
 <a href="https://pub.dev/packages/searchfield"><img src="https://img.shields.io/pub/v/searchfield.svg" alt="Pub"></a>
@@ -273,7 +273,7 @@ The position of suggestions is dynamic based on the space available for the sugg
 - `autoValidateMode`: Used to enable/disable this form field auto validation and update its error text.defaults to `AutoValidateMode.disabled`
 - `controller`: TextEditing Controller to interact with the searchfield.
 - `comparator` property to filter out the suggestions with a custom logic (Comparator is deprecated Use `onSearchTextChanged` instead).
-- `dynamicHeightItem`: Set to true to opt-in to dynamic height, defaults to false (`itemHeight : 51`)
+- `dynamicHeight`: Set to true to opt-in to dynamic height, defaults to false (`itemHeight : 51`)
 - `emptyWidget`: Custom Widget to show when search returns empty Results or when `showEmpty` is true. (defaults to `SizedBox.shrink`)
 - `enabled`: Defines whether to enable the searchfield defaults to `true`
 - `focusNode` : FocusNode to interact with the searchfield.
@@ -284,7 +284,7 @@ The position of suggestions is dynamic based on the space available for the sugg
 - `inputFormatters`: Input Formatter for SearchField
 - `itemHeight` : height of each suggestion Item, (defaults to 51.0).
 - `marginColor` : Color for the margin between the suggestions.
-- `maxSuggestionBoxHeight`: Specifies a maximum height for the suggestion box when `dynamicHeightItem` is set to `true`.
+- `maxSuggestionBoxHeight`: Specifies a maximum height for the suggestion box when `dynamicHeight` is set to `true`.
 - `maxSuggestionsInViewPort` : The max number of suggestions that can be shown in a viewport.
 - `offset` : suggestion List offset from the searchfield, The top left corner of the searchfield is the origin (0,0).
 - `onOutSideTap` : callback when the user taps outside the searchfield.

--- a/example/lib/dynamic_height.dart
+++ b/example/lib/dynamic_height.dart
@@ -40,7 +40,7 @@ class _DynamicHeightExampleState extends State<DynamicHeightExample> {
     return Padding(
       padding: const EdgeInsets.all(8.0),
       child: SearchField<UserModel>(
-        dynamicHeightItem: true,
+        dynamicHeight: true,
         // maxSuggestionBoxHeight: MediaQuery.of(context).size.height * 0.8,
         hint: 'Search for users dynamic height',
         suggestionsDecoration: SuggestionDecoration(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -130,7 +130,7 @@ class _SearchFieldSampleState extends State<SearchFieldSample> {
                 ),
                 SearchField(
                   hint: 'Basic SearchField',
-                  dynamicHeightItem: true,
+                  dynamicHeight: true,
                   maxSuggestionBoxHeight: 300,
                   initialValue: SearchFieldListItem<String>('ABC'),
                   suggestions: dynamicHeightSuggestion

--- a/lib/src/searchfield.dart
+++ b/lib/src/searchfield.dart
@@ -231,7 +231,7 @@ class SearchField<T> extends StatefulWidget {
   /// Set to true to opt-in to dynamic height. We don't calculate the total height for the whole box, instead, each item on the suggestion list will have their respective height.
   ///
   /// (Optional) Use **[maxSuggestionBoxHeight]** to set a maximum height for the suggestion box.
-  final bool dynamicHeightItem;
+  final bool dynamicHeight;
 
   /// Specifies the color of margin between items in suggestions list.
   ///
@@ -346,7 +346,7 @@ class SearchField<T> extends StatefulWidget {
     this.initialValue,
     this.inputFormatters,
     this.inputType,
-    this.dynamicHeightItem = false,
+    this.dynamicHeight = false,
     this.maxSuggestionBoxHeight,
     this.itemHeight = 51.0,
     this.marginColor,
@@ -461,7 +461,7 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
   SuggestionDirection getDirection() {
     // Early return if not flex or dynamic height
     if (_suggestionDirection != SuggestionDirection.flex &&
-        !widget.dynamicHeightItem) {
+        !widget.dynamicHeight) {
       return _suggestionDirection;
     }
     final MediaQueryData mediaQuery = MediaQuery.of(context);
@@ -718,7 +718,7 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
         } else if (snapshot.data!.isEmpty || widget.showEmpty) {
           isEmpty = true;
           _totalHeight = 0;
-        } else if (widget.dynamicHeightItem) {
+        } else if (widget.dynamicHeight) {
           _totalHeight = null;
         } else {
           final paddingHeight = widget.suggestionsDecoration != null
@@ -769,8 +769,8 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
                 behavior:
                     ScrollConfiguration.of(context).copyWith(scrollbars: false),
                 child: SFListview<T>(
-                  dynamicHeight: widget.dynamicHeightItem,
-                  maxHeight: widget.dynamicHeightItem
+                  dynamicHeight: widget.dynamicHeight,
+                  maxHeight: widget.dynamicHeight
                       ? _totalHeight ??
                           widget.maxSuggestionBoxHeight ??
                           remainingHeight
@@ -824,7 +824,7 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
       if (direction == SuggestionDirection.down) {
         return Offset(0, textFieldSize.height);
       } else if (direction == SuggestionDirection.up) {
-        if (widget.dynamicHeightItem) {
+        if (widget.dynamicHeight) {
           return Offset(
               0,
               widget.maxSuggestionBoxHeight != null
@@ -909,7 +909,7 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
   final lastSearchResult = <SearchFieldListItem<T>>[];
   @override
   Widget build(BuildContext context) {
-    if (!widget.dynamicHeightItem) {
+    if (!widget.dynamicHeight) {
       if (widget.suggestions.length > widget.maxSuggestionsInViewPort) {
         _totalHeight = widget.itemHeight * widget.maxSuggestionsInViewPort;
       } else {

--- a/lib/src/searchfield.dart
+++ b/lib/src/searchfield.dart
@@ -218,12 +218,12 @@ class SearchField<T> extends StatefulWidget {
   ///
   /// When not specified, the default value is `51.0`.
   ///
-  /// If you don't want to set a fixed item height, set **[dynamicHeightItem]** to true.
+  /// If you don't want to set a fixed item height, set **[dynamicHeight]** to true.
   final double itemHeight;
 
   /// (Optional) Specifies a maximum height for the suggestion box.
   ///
-  /// This will only take into account when setting **[dynamicHeightItem]** to true (aka. opt-in to dynamic height)
+  /// This will only take into account when setting **[dynamicHeight]** to true (aka. opt-in to dynamic height)
   ///
   /// When not specified, the default value is half the screen height.
   final double? maxSuggestionBoxHeight;


### PR DESCRIPTION
**Whats changed**

- renamed `dynamicHeightItem` to `dynamicHeight`
- Fix exception on scroll (debug) [Issue #162](https://github.com/maheshj01/searchfield/issues/162)

fixes: #162




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing using `flutter test`

If you need help, consider pinging the maintainer @maheshj01

<!-- Links -->
[Contributor Guide]: https://github.com/maheshj01/searchfield/blob/master/CONTRIBUTING.md