### PR TITLE
Add new properties to style the input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+#### [1.1.0] - September 10, 2024
+
+- Adds new properties to style the search input using `SearchInputDecoration`: `cursorColor`, `cursorWidth`, `cursorHeight`, `keyboardAppearance`, `cursorRadius`, `cursorOpacityAnimates`
+- [BREAKING] Input deocration properties are now part of `SearchInputDecoration` following are the properties moved to `SearchInputDecoration`:
+  `textCapitalization`, `searchStyle`
+
+**Before**
+
+```dart
+SearchField(
+    textCapitalization: TextCapitalization.words,
+    style: TextStyle(...)
+    ...
+)
+```
+
+**After**
+
+```dart
+SearchField(
+    searchInputDecoration: SearchInputDecoration(
+        textCapitalization: TextCapitalization.words,
+        style: TextStyle(...)
+        ...
+    )
+    ...
+),
+```
+
 #### [1.0.9] - August 05, 2024
 
 - renamed `dynamicHeightItem` to `dynamicHeight`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [searchfield: ^1.0.9](https://pub.dev/packages/searchfield)
+# [searchfield: ^1.1.0](https://pub.dev/packages/searchfield)
 
 <a href="https://github.com/maheshj01/searchfield" rel="noopener" target="_blank"><img src="https://img.shields.io/badge/platform-flutter-ff69b4.svg" alt="Flutter Platform Badge"></a>
 <a href="https://pub.dev/packages/searchfield"><img src="https://img.shields.io/pub/v/searchfield.svg" alt="Pub"></a>

--- a/example/lib/country_search.dart
+++ b/example/lib/country_search.dart
@@ -69,7 +69,9 @@ class _CountrySearchState extends State<CountrySearch> {
                       hint: 'Search by country name',
                       maxSuggestionsInViewPort: 4,
                       itemHeight: 45,
-                      textCapitalization: TextCapitalization.words,
+                      searchInputDecoration: SearchInputDecoration(
+                        textCapitalization: TextCapitalization.words,
+                      ),
                       validator: (x) {
                         if (x!.isEmpty || !containsCountry(x)) {
                           return 'Please Enter a valid Country';

--- a/example/lib/custom.dart
+++ b/example/lib/custom.dart
@@ -60,7 +60,7 @@ class _UserSelectState extends State<UserSelect> {
                 color: Colors.transparent,
                 style: BorderStyle.solid,
                 width: 1.0)),
-        searchInputDecoration: InputDecoration(
+        searchInputDecoration: SearchInputDecoration(
           filled: true,
           fillColor: Colors.grey.withOpacity(0.2),
           focusedBorder: OutlineInputBorder(

--- a/example/lib/demo.dart
+++ b/example/lib/demo.dart
@@ -115,17 +115,17 @@ class _DemoAppState extends State<DemoApp> {
                 suggestionState: Suggestion.expand,
                 textInputAction: TextInputAction.next,
                 hint: 'SearchField Example 2',
-                searchStyle: TextStyle(
-                  fontSize: 18,
-                  color: Colors.black.withOpacity(0.8),
-                ),
                 validator: (x) {
                   if (!_statesOfIndia.contains(x) || x!.isEmpty) {
                     return 'Please Enter a valid State';
                   }
                   return null;
                 },
-                searchInputDecoration: InputDecoration(
+                searchInputDecoration: SearchInputDecoration(
+                  searchStyle: TextStyle(
+                    fontSize: 18,
+                    color: Colors.black.withOpacity(0.8),
+                  ),
                   focusedBorder: OutlineInputBorder(
                     borderSide: BorderSide(
                       color: Colors.black.withOpacity(0.8),
@@ -178,7 +178,7 @@ class _DemoAppState extends State<DemoApp> {
                       color: Colors.transparent,
                       style: BorderStyle.solid,
                       width: 1.0)),
-              searchInputDecoration: InputDecoration(
+              searchInputDecoration: SearchInputDecoration(
                 filled: true,
                 fillColor: Colors.grey.withOpacity(0.2),
                 focusedBorder: OutlineInputBorder(
@@ -242,7 +242,7 @@ class _DemoAppState extends State<DemoApp> {
               suggestions:
                   _suggestions.map((e) => SearchFieldListItem(e)).toList(),
               suggestionState: Suggestion.hidden,
-              searchInputDecoration: InputDecoration(
+              searchInputDecoration: SearchInputDecoration(
                 floatingLabelBehavior: FloatingLabelBehavior.auto,
                 labelText: 'SearchField',
                 border: OutlineInputBorder(),

--- a/example/lib/dynamic_height.dart
+++ b/example/lib/dynamic_height.dart
@@ -71,7 +71,7 @@ class _DynamicHeightExampleState extends State<DynamicHeightExample> {
                 color: Colors.transparent,
                 style: BorderStyle.solid,
                 width: 1.0)),
-        searchInputDecoration: InputDecoration(
+        searchInputDecoration: SearchInputDecoration(
           filled: true,
           fillColor: Colors.grey.withOpacity(0.2),
           focusedBorder: OutlineInputBorder(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,3 @@
-import 'package:example/custom.dart';
-import 'package:example/dynamic_height.dart';
-import 'package:example/network_sample.dart';
-import 'package:example/pagination.dart';
 // import 'package:example/pagination.dart';
 import 'package:flutter/material.dart';
 import 'package:searchfield/searchfield.dart';
@@ -42,27 +38,6 @@ class SearchFieldSample extends StatefulWidget {
 }
 
 class _SearchFieldSampleState extends State<SearchFieldSample> {
-  int suggestionsCount = 12;
-  final focus = FocusNode();
-  final dynamicHeightSuggestion = [
-    'ABC\nABC\nABC\nABC',
-    'DEF\nABC',
-    'GHI',
-    'JKL\nABC',
-    'ABC',
-    '123\n123',
-    '123\n123',
-    '123\n123',
-    '123\n123',
-    '123\n123',
-    '123\n123',
-    'àkajsddddddddddddddddddddddddddddddddddddddddddddddddddđ',
-    'àkajsddddddddddddddddddddddddddddddddddddddddddddddddddđ',
-    'àkajsddddddddddddddddddddddddddddddddddddddddddddddddddđ',
-    'àkajsddddddddddddddddddddddddddddddddddddddddddddddddddđ',
-    'àkajsddddddddddddddddddddddddddddddddddddddddddddddddddđ',
-  ];
-
   @override
   void initState() {
     suggestions = [
@@ -88,217 +63,48 @@ class _SearchFieldSampleState extends State<SearchFieldSample> {
       'Nigeria',
       'Egypt',
     ];
+    selected = suggestions[0];
     super.initState();
   }
 
   final TextEditingController searchController = TextEditingController();
   var suggestions = <String>[];
   int counter = 0;
+  var selected = '';
   @override
   Widget build(BuildContext context) {
-    Widget searchChild(x) => Padding(
-          padding: const EdgeInsets.symmetric(vertical: 4.0, horizontal: 12),
-          child: Text(x, style: TextStyle(fontSize: 18, color: Colors.black)),
+    Widget searchChild(x, isSelected) => Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: Text(x,
+              style: TextStyle(
+                  fontSize: 18,
+                  color: isSelected ? Colors.green : Colors.black)),
         );
     return Scaffold(
         appBar: AppBar(title: Text('Searchfield Demo')),
-        floatingActionButton: FloatingActionButton(
-          onPressed: () {
-            setState(() {
-              suggestionsCount++;
-              counter++;
-              suggestions.add('suggestion $suggestionsCount');
-            });
-          },
-          child: Icon(Icons.add),
-        ),
-        body: GestureDetector(
-          onTap: () {
-            FocusScope.of(context).unfocus();
-          },
-          child: Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: ListView(
-              children: [
-                UserSelect(),
-                SizedBox(
-                  height: 20,
-                ),
-                DynamicHeightExample(),
-                SizedBox(
-                  height: 20,
-                ),
-                SearchField(
-                  hint: 'Basic SearchField',
-                  dynamicHeight: true,
-                  maxSuggestionBoxHeight: 300,
-                  initialValue: SearchFieldListItem<String>('ABC'),
-                  suggestions: dynamicHeightSuggestion
-                      .map(SearchFieldListItem<String>.new)
-                      .toList(),
-                  suggestionState: Suggestion.expand,
-                ),
-                SizedBox(
-                  height: 20,
-                ),
-                TextFormField(
-                    autovalidateMode: AutovalidateMode.onUserInteraction,
-                    decoration: InputDecoration(
-                      labelText: 'Flutter TextFormField',
-                    ),
-                    validator: (value) {
-                      if (value == null || value.length < 4) {
-                        return 'error';
-                      }
-                      return null;
-                    }),
-                SizedBox(
-                  height: 50,
-                ),
-                Pagination(),
-                SizedBox(
-                  height: 50,
-                ),
-                SearchField<String>(
-                  maxSuggestionsInViewPort: 10,
-                  suggestions: suggestions
-                      .map(
-                        (e) => SearchFieldListItem<String>(
-                          e,
-                          item: e,
-                          child: Padding(
-                            padding: const EdgeInsets.all(8.0),
-                            child: Text(e),
-                          ),
-                        ),
-                      )
-                      .toList(),
-                ),
-                SizedBox(
-                  height: 50,
-                ),
-                NetworkSample(),
-                SizedBox(
-                  height: 50,
-                ),
-                SearchField(
-                  suggestionDirection: SuggestionDirection.flex,
-                  onSearchTextChanged: (query) {
-                    final filter = suggestions
-                        .where((element) =>
-                            element.toLowerCase().contains(query.toLowerCase()))
-                        .toList();
-                    return filter
-                        .map((e) => SearchFieldListItem<String>(e,
-                            child: searchChild(e)))
-                        .toList();
-                  },
-                  initialValue: SearchFieldListItem<String>('United States'),
-                  controller: searchController,
-                  autovalidateMode: AutovalidateMode.onUserInteraction,
-                  validator: (value) {
-                    if (value == null || !suggestions.contains(value.trim())) {
-                      return 'Enter a valid country name';
-                    }
-                    return null;
-                  },
-                  onSubmit: (x) {},
-                  autofocus: false,
-                  key: const Key('searchfield'),
-                  hint: 'Search by country name',
-                  itemHeight: 50,
-                  onTapOutside: (x) {
-                    // focus.unfocus();
-                  },
-                  scrollbarDecoration: ScrollbarDecoration(
-                    thickness: 12,
-                    radius: Radius.circular(6),
-                    trackColor: Colors.grey,
-                    trackBorderColor: Colors.red,
-                    thumbColor: Colors.orange,
-                  ),
-                  suggestionStyle:
-                      const TextStyle(fontSize: 18, color: Colors.black),
-                  searchStyle: TextStyle(fontSize: 18, color: Colors.black),
-                  suggestionItemDecoration: BoxDecoration(
-                    // color: Colors.grey[100],
-                    // borderRadius: BorderRadius.circular(10),
-                    border: Border(
-                      bottom: BorderSide(
-                        color: Colors.grey.shade200,
-                        width: 1,
-                      ),
-                    ),
-                  ),
-                  searchInputDecoration: InputDecoration(
-                    hintStyle: TextStyle(fontSize: 18, color: Colors.grey),
-                    focusedBorder: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(24),
-                      borderSide: const BorderSide(
-                        width: 1,
-                        color: Colors.orange,
-                        style: BorderStyle.solid,
-                      ),
-                    ),
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(24),
-                      borderSide: const BorderSide(
-                        width: 1,
-                        color: Colors.black,
-                        style: BorderStyle.solid,
-                      ),
-                    ),
-                    contentPadding: const EdgeInsets.symmetric(
-                      horizontal: 20,
-                    ),
-                  ),
-                  suggestionsDecoration: SuggestionDecoration(
-                      // border: Border.all(color: Colors.orange),
-                      elevation: 8.0,
-                      selectionColor: Colors.grey.shade100,
-                      hoverColor: Colors.purple.shade100,
-                      gradient: LinearGradient(
-                        colors: [
-                          Color(0xfffc466b),
-                          Color.fromARGB(255, 103, 128, 255)
-                        ],
-                        stops: [0.25, 0.75],
-                        begin: Alignment.topLeft,
-                        end: Alignment.bottomRight,
-                      ),
-                      borderRadius: BorderRadius.only(
-                        bottomLeft: Radius.circular(10),
-                        bottomRight: Radius.circular(10),
-                      )),
-                  suggestions: suggestions
-                      .map((e) =>
-                          SearchFieldListItem<String>(e, child: searchChild(e)))
-                      .toList(),
-                  focusNode: focus,
-                  suggestionState: Suggestion.expand,
-                  onSuggestionTap: (SearchFieldListItem<String> x) {},
-                ),
-                SizedBox(
-                  height: 50,
-                ),
-                SearchField(
-                  enabled: false,
-                  hint: 'Disabled SearchField',
-                  suggestions: ['ABC', 'DEF', 'GHI', 'JKL']
-                      .map(SearchFieldListItem<String>.new)
-                      .toList(),
-                  suggestionState: Suggestion.expand,
-                ),
-                SizedBox(
-                  height: 50,
-                ),
-                NetworkSample(),
-                Text(
-                  'Counter: $counter',
-                  style: Theme.of(context).textTheme.bodyLarge,
-                ),
-              ],
+        body: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: SearchField<String>(
+            maxSuggestionsInViewPort: 10,
+            suggestionAction: SuggestionAction.unfocus,
+            searchInputDecoration: SearchInputDecoration(
+              hintText: 'Search',
+              cursorColor: Colors.red,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
             ),
+            onSuggestionTap: (SearchFieldListItem<String> item) {
+              setState(() {
+                selected = item.searchKey;
+              });
+            },
+            suggestions: suggestions
+                .map(
+                  (e) => SearchFieldListItem<String>(e,
+                      item: e, child: searchChild(e, e == selected)),
+                )
+                .toList(),
           ),
         ));
   }

--- a/example/lib/network_sample.dart
+++ b/example/lib/network_sample.dart
@@ -89,7 +89,7 @@ class _NetworkSampleState extends State<NetworkSample> {
           onTapOutside: (x) {},
           suggestionDirection: SuggestionDirection.up,
           suggestionStyle: const TextStyle(fontSize: 20, color: Colors.black),
-          searchInputDecoration: InputDecoration(
+          searchInputDecoration: SearchInputDecoration(
             focusedBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(24),
               borderSide: const BorderSide(

--- a/example/lib/pagination.dart
+++ b/example/lib/pagination.dart
@@ -110,7 +110,7 @@ class _PaginationState extends State<Pagination> {
           scrollbarDecoration: ScrollbarDecoration(),
           onTapOutside: (x) {},
           suggestionStyle: const TextStyle(fontSize: 20, color: Colors.black),
-          searchInputDecoration: InputDecoration(
+          searchInputDecoration: SearchInputDecoration(
             focusedBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(24),
               borderSide: const BorderSide(

--- a/lib/searchfield.dart
+++ b/lib/searchfield.dart
@@ -1,2 +1,3 @@
 export 'src/decoration.dart';
+export 'src/input_decoration.dart';
 export 'src/searchfield.dart';

--- a/lib/src/input_decoration.dart
+++ b/lib/src/input_decoration.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+
+class SearchInputDecoration extends InputDecoration {
+  /// text capitalization defaults to [TextCapitalization.none]
+  final TextCapitalization textCapitalization;
+
+  /// Specifies [TextStyle] for search input.
+  final TextStyle? searchStyle;
+
+  /// The color of the cursor.
+  /// The cursor indicates the current location of text insertion point in the field.
+  /// If this is null it will default to the ambient DefaultSelectionStyle.cursorColor. If that is
+  /// null, and the ThemeData.platform is TargetPlatform.iOS or TargetPlatform.macOS it will use
+  /// CupertinoThemeData.primaryColor. Otherwise it will use the value of ColorScheme.primary of
+  /// ThemeData.colorScheme.
+  ///
+  final Color cursorColor;
+
+  ///Creates a [FormField] that contains a [TextField].
+
+  /// The color of the cursor when the InputDecorator is showing an error.
+  ///
+  /// If this is null it will default to TextStyle.color of InputDecoration.errorStyle. If that is
+  /// null, it will use ColorScheme.error of ThemeData.colorScheme.
+  ///
+  final Color? cursorErrorColor;
+
+  /// How tall the cursor will be.
+  ///
+  /// If this property is null, RenderEditable.preferredLineHeight will be used.
+  final double? cursorHeight;
+
+  /// How thick the cursor will be.
+  /// Defaults to 2.0.
+  /// The cursor will draw under the text. The cursor width will extend to the right of the
+  /// boundary between characters for left-to-right text and to the left for right-to-left text.
+  /// This corresponds to extending downstream relative to the selected position. Negative values
+  /// may be used to reverse this behavior.
+  ///
+  final double? cursorWidth;
+
+  /// Whether the cursor will animate from fully transparent to fully opaque during each cursor
+  /// blink.
+  /// By default, the cursor opacity will animate on iOS platforms and will not animate on Android /
+  /// platforms.
+  ///
+  final bool? cursorOpacityAnimates;
+
+  /// The radius of the cursor.How rounded the corners of the cursor should be.
+  /// By default, the cursor has no radius.
+  ///
+  final Radius? cursorRadius;
+
+  /// The appearance of the keyboard.
+  /// This setting is only honored on iOS devices.
+  ///
+  /// If unset, defaults to ThemeData.brightness.
+  ///
+  final Brightness? keyboardAppearance;
+
+  final Key? key;
+  SearchInputDecoration({
+    this.key,
+    this.cursorColor = Colors.black,
+    this.textCapitalization = TextCapitalization.none,
+    this.searchStyle,
+    this.cursorErrorColor,
+    this.cursorHeight,
+    this.cursorWidth = 2.0,
+    this.cursorOpacityAnimates,
+    this.cursorRadius,
+    this.keyboardAppearance,
+    super.border,
+    super.enabledBorder,
+    super.focusedBorder,
+    super.errorBorder,
+    super.focusedErrorBorder,
+    super.disabledBorder,
+    super.contentPadding,
+    super.hintText,
+    super.hintStyle,
+    super.labelText,
+    super.labelStyle,
+    super.prefixText,
+    super.prefixStyle,
+    super.suffixText,
+    super.suffixStyle,
+    super.counterText,
+    super.counterStyle,
+    super.filled,
+    super.fillColor,
+    super.focusColor,
+    super.hoverColor,
+    super.icon,
+    super.iconColor,
+    super.isCollapsed,
+    super.isDense,
+    super.floatingLabelBehavior,
+    super.floatingLabelAlignment,
+    super.alignLabelWithHint,
+    super.enabled,
+    super.constraints,
+    super.counter,
+    super.semanticCounterText,
+    super.helperText,
+    super.helperStyle,
+    super.helperMaxLines,
+    super.errorMaxLines,
+    super.errorStyle,
+  });
+}

--- a/lib/src/searchfield.dart
+++ b/lib/src/searchfield.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:searchfield/src/decoration.dart';
+import 'package:searchfield/src/input_decoration.dart';
 import 'package:searchfield/src/key_intents.dart';
 import 'package:searchfield/src/listview.dart';
 
@@ -155,9 +156,6 @@ class SearchField<T> extends StatefulWidget {
   /// When not specified, [hint] is shown instead of `initialValue`.
   final SearchFieldListItem<T>? initialValue;
 
-  /// Specifies [TextStyle] for search input.
-  final TextStyle? searchStyle;
-
   /// Specifies [TextStyle] for suggestions when no child is provided
   /// in [SearchFieldListItem].
   final TextStyle? suggestionStyle;
@@ -166,7 +164,7 @@ class SearchField<T> extends StatefulWidget {
   ///
   /// When not specified, the default value is [InputDecoration] initialized
   /// with [hint].
-  final InputDecoration? searchInputDecoration;
+  late SearchInputDecoration? searchInputDecoration;
 
   /// defaults to SuggestionState.expand
   final Suggestion suggestionState;
@@ -248,7 +246,7 @@ class SearchField<T> extends StatefulWidget {
   /// Specifies the `TextEditingController` for [SearchField].
   final TextEditingController? controller;
 
-  /// Keyboard Type for SearchField
+  /// Keyboard Type for SearchField defaults to [TextInputType.text]
   final TextInputType? inputType;
 
   /// `validator` for the [SearchField]
@@ -328,9 +326,6 @@ class SearchField<T> extends StatefulWidget {
   /// suggestion direction defaults to [SuggestionDirection.down]
   final SuggestionDirection suggestionDirection;
 
-  /// text capitalization defaults to [TextCapitalization.none]
-  final TextCapitalization textCapitalization;
-
   SearchField({
     Key? key,
     required this.suggestions,
@@ -364,7 +359,6 @@ class SearchField<T> extends StatefulWidget {
     this.offset,
     this.onSuggestionTap,
     this.searchInputDecoration,
-    this.searchStyle,
     this.scrollbarDecoration,
     this.showEmpty = false,
     this.suggestionStyle,
@@ -374,7 +368,6 @@ class SearchField<T> extends StatefulWidget {
     this.suggestionItemDecoration,
     this.suggestionAction,
     this.textAlign = TextAlign.start,
-    this.textCapitalization = TextCapitalization.none,
     this.textInputAction,
     this.validator,
   })  : assert(
@@ -397,6 +390,17 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
 
   // Use to calculate suggestion box height if [widget.maxSuggestionBoxHeight] is not specified
   double remainingHeight = 0;
+
+  final _defaultSearchInputDecoration = SearchInputDecoration(
+    hintText: 'Search',
+    textCapitalization: TextCapitalization.none,
+    cursorWidth: 2.0,
+    cursorColor: Colors.black,
+    cursorHeight: 20.0,
+    cursorOpacityAnimates: true,
+    keyboardAppearance: Brightness.light,
+    cursorRadius: Radius.circular(10.0),
+  );
 
   @override
   void dispose() {
@@ -422,6 +426,9 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
   }
 
   void initialize() {
+    if (widget.searchInputDecoration == null) {
+      widget.searchInputDecoration = _defaultSearchInputDecoration;
+    }
     if (widget.scrollbarDecoration == null) {
       _scrollbarDecoration = ScrollbarDecoration();
     } else {
@@ -660,6 +667,10 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
     if (oldWidget.initialValue != widget.initialValue) {
       selected = widget.suggestions
           .indexWhere((element) => element == widget.initialValue);
+    }
+    if (oldWidget.searchInputDecoration != widget.searchInputDecoration) {
+      widget.searchInputDecoration =
+          widget.searchInputDecoration ?? _defaultSearchInputDecoration;
     }
 
     super.didUpdateWidget(oldWidget);
@@ -969,14 +980,24 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
               inputFormatters: widget.inputFormatters,
               controller: searchController,
               focusNode: _searchFocus,
+              cursorErrorColor: widget.searchInputDecoration?.cursorErrorColor,
+              cursorHeight: widget.searchInputDecoration?.cursorHeight,
+              cursorWidth: widget.searchInputDecoration?.cursorWidth ?? 2.0,
+              cursorOpacityAnimates:
+                  widget.searchInputDecoration?.cursorOpacityAnimates,
+              cursorRadius: widget.searchInputDecoration?.cursorRadius,
+              keyboardAppearance:
+                  widget.searchInputDecoration?.keyboardAppearance,
               validator: widget.validator,
-              style: widget.searchStyle,
+              style: widget.searchInputDecoration?.searchStyle,
               textInputAction: widget.textInputAction,
-              textCapitalization: widget.textCapitalization,
+              textCapitalization:
+                  widget.searchInputDecoration!.textCapitalization,
               keyboardType: widget.inputType,
+              cursorColor: widget.searchInputDecoration?.cursorColor,
               decoration: widget.searchInputDecoration
                       ?.copyWith(hintText: widget.hint) ??
-                  InputDecoration(hintText: widget.hint),
+                  _defaultSearchInputDecoration,
               onChanged: (query) {
                 var searchResult = <SearchFieldListItem<T>>[];
                 if (widget.onSearchTextChanged != null) {

--- a/lib/src/searchfield.dart
+++ b/lib/src/searchfield.dart
@@ -86,6 +86,7 @@ extension ListContainsObject<T> on List {
 /// when the searchfield is brought into focus
 /// see [example/lib/country_search.dart]
 ///
+// ignore: must_be_immutable
 class SearchField<T> extends StatefulWidget {
   /// duration of the suggestion list animation
   final Duration animationDuration;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: searchfield
 description: A highly customizable, simple and easy to use flutter Widget to add a searchfield to your Flutter Application. This Widget allows you to search and select from list of suggestions.
-version: 1.0.9
+version: 1.1.0
 homepage: https://github.com/maheshj01/searchfield
 repository: https://github.com/maheshj01/searchfield
 issue_tracker: https://github.com/maheshj01/searchfield/issues

--- a/test/searchfield_test.dart
+++ b/test/searchfield_test.dart
@@ -1042,7 +1042,9 @@ void main() {
               color: Colors.transparent, style: BorderStyle.solid, width: 1.0)),
       suggestions:
           ['ABC', 'DEF', 'def'].map(SearchFieldListItem<String>.new).toList(),
-      textCapitalization: TextCapitalization.characters,
+      searchInputDecoration: SearchInputDecoration(
+        textCapitalization: TextCapitalization.characters,
+      ),
     )));
     final finder = find.byType(TextField);
     final textField = tester.firstWidget<TextField>(finder);


### PR DESCRIPTION
Addresses Issue: #167

- Adds new properties to style the search input using `SearchInputDecoration`: `cursorColor`, `cursorWidth`, `cursorHeight`, `keyboardAppearance`, `cursorRadius`, `cursorOpacityAnimates`
- [BREAKING] Input deocration properties are now part of `SearchInputDecoration` following are the properties moved to `SearchInputDecoration`:
  `textCapitalization`, `searchStyle`

**Before**

```dart
SearchField(
    textCapitalization: TextCapitalization.words,
    style: TextStyle(...)
    ...
)
```

**After**

```dart
SearchField(
    searchInputDecoration: SearchInputDecoration(
        textCapitalization: TextCapitalization.words,
        style: TextStyle(...)
        ...
    )
    ...
),
```

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing using `flutter test`

If you need help, consider pinging the maintainer @maheshj01

<!-- Links -->
[Contributor Guide]: https://github.com/maheshj01/searchfield/blob/master/CONTRIBUTING.md