### PR TITLE
Refactor `SearchInputDecoration` class added maintainHintHeight

### DIFF
--- a/lib/src/input_decoration.dart
+++ b/lib/src/input_decoration.dart
@@ -58,6 +58,8 @@ class SearchInputDecoration extends InputDecoration {
   ///
   final Brightness? keyboardAppearance;
 
+  
+
   final Key? key;
   SearchInputDecoration({
     this.key,
@@ -122,6 +124,7 @@ class SearchInputDecoration extends InputDecoration {
     super.errorMaxLines,
     super.errorStyle,
     super.suffixIconConstraints,
+    super.maintainHintHeight,
   });
   
   @override
@@ -189,6 +192,7 @@ class SearchInputDecoration extends InputDecoration {
     BoxConstraints? suffixIconConstraints,
     TextStyle? suffixStyle,
     String? suffixText,
+    bool? maintainHintHeight,
   }) {
     return SearchInputDecoration(
       cursorErrorColor: cursorErrorColor ?? this.cursorErrorColor,
@@ -243,6 +247,8 @@ class SearchInputDecoration extends InputDecoration {
       suffixIconColor: suffixIconColor ?? this.suffixIconColor,
       suffixStyle: suffixStyle ?? this.suffixStyle,
       suffixText: suffixText ?? this.suffixText,
+      maintainHintHeight:
+          maintainHintHeight ?? this.maintainHintHeight,
     );
   }
 }


### PR DESCRIPTION
This commit refactors the `SearchInputDecoration` class in `input_decoration.dart`. It adds a new property `maintainHintHeight` and updates the constructor and methods accordingly. This change improves the flexibility and customization options for the `SearchInputDecoration` class.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing using `flutter test`

If you need help, consider pinging the maintainer @maheshj01

<!-- Links -->
[Contributor Guide]: https://github.com/maheshj01/searchfield/blob/master/CONTRIBUTING.md