### PR TITLE
Remove Null Checker

### DIFF
--- a/lib/src/searchfield.dart
+++ b/lib/src/searchfield.dart
@@ -675,7 +675,9 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
     if (oldWidget.selectedValue != widget.selectedValue) {
       // highlightIndex = widget.suggestions
       //     .indexWhere((element) => element == widget.selectedValue);
-      searchController!.text = widget.selectedValue!.searchKey;
+
+      //Just made removed the null check, so that I can clear the field by defining the selectedValue to null
+      searchController!.text = widget.selectedValue?.searchKey ?? '';
     }
     if (oldWidget.searchInputDecoration != widget.searchInputDecoration) {
       widget.searchInputDecoration =


### PR DESCRIPTION
Just removed the null check, now the field can be cleared by defining the `selectedValue` to null.

Before, if you tried to clear the selected value, you would get this error:

```
════════ Exception caught by widgets library ═══════════════════════════════════
The following _TypeError was thrown building SearchCitiesField(dependencies: [_LocalizationsScope-[GlobalKey#93cef]]):
Null check operator used on a null value

The relevant error-causing widget was:
    SearchCitiesField SearchCitiesField:file:///D:/Projects/Flutter/Fun%20Projects/planner_app/lib/ui/register/widgets/information_card.dart:78:38

When the exception was thrown, this was the stack:
#0      _SearchFieldState.didUpdateWidget (package:searchfield/src/searchfield.dart:678:52)
searchfield.dart:678
#1      StatefulElement.update (package:flutter/src/widgets/framework.dart:5803:55)
framework.dart:5803
#2      Element.updateChild (package:flutter/src/widgets/framework.dart:3941:15)
framework.dart:3941
#3      ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:5656:16)
framework.dart:5656
#4      Element.rebuild (package:flutter/src/widgets/framework.dart:5347:7)
framework.dart:5347
...
```

But now it works perfectly.