### PR TITLE
 fixed issue #20 - The superclass, 'InputDecoration', has no unnamed constructor that takes no arguments

### DIFF
--- a/lib/src/input_decoration.dart
+++ b/lib/src/input_decoration.dart
@@ -1,66 +1,17 @@
 import 'package:flutter/material.dart';
 
 class SearchInputDecoration extends InputDecoration {
-  /// text capitalization defaults to [TextCapitalization.none]
   final TextCapitalization textCapitalization;
-
-  /// Specifies [TextStyle] for search input.
   final TextStyle? searchStyle;
-
-  /// The color of the cursor.
-  /// The cursor indicates the current location of text insertion point in the field.
-  /// If this is null it will default to the ambient DefaultSelectionStyle.cursorColor. If that is
-  /// null, and the ThemeData.platform is TargetPlatform.iOS or TargetPlatform.macOS it will use
-  /// CupertinoThemeData.primaryColor. Otherwise it will use the value of ColorScheme.primary of
-  /// ThemeData.colorScheme.
-  ///
   final Color cursorColor;
-
-  ///Creates a [FormField] that contains a [TextField].
-
-  /// The color of the cursor when the InputDecorator is showing an error.
-  ///
-  /// If this is null it will default to TextStyle.color of InputDecoration.errorStyle. If that is
-  /// null, it will use ColorScheme.error of ThemeData.colorScheme.
-  ///
   final Color? cursorErrorColor;
-
-  /// How tall the cursor will be.
-  ///
-  /// If this property is null, RenderEditable.preferredLineHeight will be used.
   final double? cursorHeight;
-
-  /// How thick the cursor will be.
-  /// Defaults to 2.0.
-  /// The cursor will draw under the text. The cursor width will extend to the right of the
-  /// boundary between characters for left-to-right text and to the left for right-to-left text.
-  /// This corresponds to extending downstream relative to the selected position. Negative values
-  /// may be used to reverse this behavior.
-  ///
   final double? cursorWidth;
-
-  /// Whether the cursor will animate from fully transparent to fully opaque during each cursor
-  /// blink.
-  /// By default, the cursor opacity will animate on iOS platforms and will not animate on Android /
-  /// platforms.
-  ///
   final bool? cursorOpacityAnimates;
-
-  /// The radius of the cursor.How rounded the corners of the cursor should be.
-  /// By default, the cursor has no radius.
-  ///
   final Radius? cursorRadius;
-
-  /// The appearance of the keyboard.
-  /// This setting is only honored on iOS devices.
-  ///
-  /// If unset, defaults to ThemeData.brightness.
-  ///
   final Brightness? keyboardAppearance;
 
-  final Key? key;
   SearchInputDecoration({
-    this.key,
     this.cursorColor = Colors.black,
     this.textCapitalization = TextCapitalization.none,
     this.searchStyle,
@@ -83,7 +34,6 @@ class SearchInputDecoration extends InputDecoration {
     super.suffixIcon,
     super.suffix,
     super.label,
-    super.maintainHintHeight,
     super.suffixIconColor,
     super.prefix,
     super.prefixIconColor,
@@ -123,7 +73,7 @@ class SearchInputDecoration extends InputDecoration {
     super.errorMaxLines,
     super.errorStyle,
     super.suffixIconConstraints,
-  });
+  }) : super(); // Call the default constructor of InputDecoration
 
   @override
   SearchInputDecoration copyWith({
@@ -193,7 +143,6 @@ class SearchInputDecoration extends InputDecoration {
     String? suffixText,
   }) {
     return SearchInputDecoration(
-      maintainHintHeight: maintainHintHeight ?? this.maintainHintHeight,
       cursorColor: cursorColor ?? this.cursorColor,
       textCapitalization: textCapitalization ?? this.textCapitalization,
       searchStyle: searchStyle ?? this.searchStyle,


### PR DESCRIPTION
I fixed this [issue](https://github.com/maheshj01/searchfield/issues/200) by modifying the "lib/src/input_decoration.dart".

Note: In this fixed I removed the "maintainHintHeight" from the "SearchInputDecoration", because it was giving an error you can consider re-adding and/or modifying it. 