### PR TITLE
Set overlay entry to null when removing it

### DIFF
--- a/lib/src/searchfield.dart
+++ b/lib/src/searchfield.dart
@@ -435,9 +435,8 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
   void removeOverlay() {
     if (_overlayEntry != null && _overlayEntry!.mounted) {
       isSuggestionsShown = false;
-      if (_overlayEntry != null) {
-        _overlayEntry?.remove();
-      }
+      _overlayEntry?.remove();
+      _overlayEntry = null;
     }
   }
 


### PR DESCRIPTION
Fixes [43](https://github.com/maheshj01/searchfield/issues/43). In that thread, it was concluded that there was a bug in the Flutter framework and the issue 43 couldn't progress until that bug was fixed. The [filed Flutter issue](https://github.com/flutter/flutter/issues/145466) did progress – it mentions the fix I am contributing in this PR.

I can confirm setting the `overlayEntry` to `null` when removing the overlay fixes issue 43 and seems like a logical thing to do. I have additionally removed the redundant null check, as the null aware operator `?` does the same thing already.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`). _Not applicable_
- [x] I added new tests to check the change I am making, or this PR is [test-exempt]. _No tests were added for this bugfix_
- [x] All existing and new tests are passing using `flutter test`