### PR TITLE
Bug fix: Cannot modify immutable list

### DIFF
--- a/lib/src/searchfield.dart
+++ b/lib/src/searchfield.dart
@@ -708,7 +708,7 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
     if (!listEquals(oldWidget.suggestions, widget.suggestions)) {
       length = widget.suggestions.length;
       suggestionStream.sink.add(widget.suggestions);
-      filteredResult.clear();
+      filteredResult = [];
       filteredResult.addAll(widget.suggestions);
       // if a item was already selected
       if (highlightIndex >= 0) {


### PR DESCRIPTION
I encountered this bug,
```
════════ Exception caught by widgets library ═══════════════════════════════════
The following UnsupportedError was thrown building MapLocationSelectWidget(dependencies: [InheritedCupertinoTheme, _InheritedTheme, _LocalizationsScope-[GlobalKey#50ace]], state: _MapLocationSelectWidgetState#fc789):
Unsupported operation: Cannot clear an unmodifiable list

The relevant error-causing widget was:
MapLocationSelectWidget MapLocationSelectWidget:file:///D:/Ahsan/Job/Point-of-Sale-Project/frontend/lib/components/widgets/form/address_field.dart:85:9

When the exception was thrown, this was the stack:
#0 UnmodifiableListMixin.clear (dart:_internal/list.dart:157:5)
list.dart:157
#1 _SearchFieldState.didUpdateWidget (package:searchfield/src/searchfield.dart:711:22)
```
Can't modify immutable list. So I replaced filteredResult.clear() with filteredResult = [].


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing using `flutter test`

If you need help, consider pinging the maintainer @maheshj01

<!-- Links -->
[Contributor Guide]: https://github.com/maheshj01/searchfield/blob/master/CONTRIBUTING.md