### PR TITLE
Fix 239

### DIFF
--- a/lib/src/input_decoration.dart
+++ b/lib/src/input_decoration.dart
@@ -83,11 +83,6 @@ class SearchInputDecoration extends InputDecoration {
     super.suffixIcon,
     super.suffix,
     super.label,
-    @Deprecated(
-      'Use maintainHintSize instead. '
-      'This will maintain both hint height and hint width. '
-      'This feature was deprecated after v1.26.0',
-    )
     super.maintainHintHeight,
     super.suffixIconColor,
     super.prefix,
@@ -197,7 +192,6 @@ class SearchInputDecoration extends InputDecoration {
     BoxConstraints? suffixIconConstraints,
     TextStyle? suffixStyle,
     String? suffixText,
-    bool? maintainHintSize,
   }) {
     return SearchInputDecoration(
       cursorColor: cursorColor ?? this.cursorColor,

--- a/lib/src/input_decoration.dart
+++ b/lib/src/input_decoration.dart
@@ -89,7 +89,6 @@ class SearchInputDecoration extends InputDecoration {
       'This feature was deprecated after v1.26.0',
     )
     super.maintainHintHeight,
-    super.maintainHintSize,
     super.suffixIconColor,
     super.prefix,
     super.prefixIconColor,
@@ -100,7 +99,6 @@ class SearchInputDecoration extends InputDecoration {
     super.disabledBorder,
     super.contentPadding,
     super.hintText,
-    super.hint,
     super.hintStyle,
     super.labelText,
     super.labelStyle,
@@ -202,28 +200,22 @@ class SearchInputDecoration extends InputDecoration {
     bool? maintainHintSize,
   }) {
     return SearchInputDecoration(
-      maintainHintHeight: maintainHintHeight ?? this.maintainHintHeight,
-      maintainHintSize: maintainHintSize ?? this.maintainHintSize,
       cursorColor: cursorColor ?? this.cursorColor,
       textCapitalization: textCapitalization ?? this.textCapitalization,
       searchStyle: searchStyle ?? this.searchStyle,
-      prefixIconConstraints:
-          prefixIconConstraints ?? this.prefixIconConstraints,
-      suffixIconConstraints:
-          suffixIconConstraints ?? this.suffixIconConstraints,
+      prefixIconConstraints: prefixIconConstraints ?? this.prefixIconConstraints,
+      suffixIconConstraints: suffixIconConstraints ?? this.suffixIconConstraints,
       hintMaxLines: hintMaxLines ?? this.hintMaxLines,
       floatingLabelStyle: floatingLabelStyle ?? this.floatingLabelStyle,
       errorText: errorText ?? this.errorText,
       error: error ?? this.error,
       hintTextDirection: hintTextDirection ?? this.hintTextDirection,
-      hint: hint ?? this.hint,
       hintFadeDuration: hintFadeDuration ?? this.hintFadeDuration,
       helper: helper ?? this.helper,
       cursorErrorColor: cursorErrorColor ?? this.cursorErrorColor,
       cursorHeight: cursorHeight ?? this.cursorHeight,
       cursorWidth: cursorWidth ?? this.cursorWidth,
-      cursorOpacityAnimates:
-          cursorOpacityAnimates ?? this.cursorOpacityAnimates,
+      cursorOpacityAnimates: cursorOpacityAnimates ?? this.cursorOpacityAnimates,
       cursorRadius: cursorRadius ?? this.cursorRadius,
       keyboardAppearance: keyboardAppearance ?? this.keyboardAppearance,
       alignLabelWithHint: alignLabelWithHint ?? this.alignLabelWithHint,
@@ -240,10 +232,8 @@ class SearchInputDecoration extends InputDecoration {
       errorStyle: errorStyle ?? this.errorStyle,
       fillColor: fillColor ?? this.fillColor,
       filled: filled ?? this.filled,
-      floatingLabelAlignment:
-          floatingLabelAlignment ?? this.floatingLabelAlignment,
-      floatingLabelBehavior:
-          floatingLabelBehavior ?? this.floatingLabelBehavior,
+      floatingLabelAlignment: floatingLabelAlignment ?? this.floatingLabelAlignment,
+      floatingLabelBehavior: floatingLabelBehavior ?? this.floatingLabelBehavior,
       focusColor: focusColor ?? this.focusColor,
       focusedBorder: focusedBorder ?? this.focusedBorder,
       focusedErrorBorder: focusedErrorBorder ?? this.focusedErrorBorder,


### PR DESCRIPTION
👉 These parameters (maintainHintSize, hint) do not exist anymore in Flutter’s InputDecoration class (they were removed in Flutter 3.24). The searchfield package version 1.3.3 is outdated and not compatible with your Flutter version.

This change removes the deprecated maintainHintSize and hint constructor parameters which are causing compile time error in Flutter versions later than 3.24.

I didn't add a unit test for this, there is nothing to test regarding this, it's a compile time error. All the available tests are passing
<img width="417" height="76" alt="image" src="https://github.com/user-attachments/assets/8f6ddfd5-59bc-444f-b477-7d29d88151ed" />

* https://github.com/maheshj01/searchfield/issues/239
* https://github.com/maheshj01/searchfield/issues/243

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing using `flutter test`

If you need help, consider pinging the maintainer @maheshj01

<!-- Links -->
[Contributor Guide]: https://github.com/maheshj01/searchfield/blob/master/CONTRIBUTING.md